### PR TITLE
Feat/add admin routes (新增後台管理路由)

### DIFF
--- a/controllers/admin-controller.js
+++ b/controllers/admin-controller.js
@@ -26,5 +26,18 @@ module.exports = {
       return res.status(200).json(tweets)
 
     } catch (err) { next(err) }
+  },
+
+  deleteTweet: async (req, res, next) => {
+    try {
+      const { TweetId } = req.params
+
+      const tweet = await Tweet.findByPk(TweetId)
+      if (!tweet) throw new Error('這則推文已不存在!')
+
+      const responseData = await tweet.destroy()
+      return res.status(200).json(responseData)
+
+    } catch (err) { next(err) }
   }
 }

--- a/controllers/admin-controller.js
+++ b/controllers/admin-controller.js
@@ -1,4 +1,4 @@
-const { User } = require('../models')
+const { User, Tweet } = require('../models')
 
 module.exports = {
   getUsers: async (req, res, next) => {
@@ -11,6 +11,19 @@ module.exports = {
       })
 
       return res.status(200).json(users)
+
+    } catch (err) { next(err) }
+  },
+
+  getTweets: async (req, res, next) => {
+    try {
+      const tweets = await Tweet.findAll({
+        order: [['createdAt', 'DESC']],
+        raw: true,
+        nest: true
+      })
+
+      return res.status(200).json(tweets)
 
     } catch (err) { next(err) }
   }

--- a/controllers/admin-controller.js
+++ b/controllers/admin-controller.js
@@ -1,0 +1,17 @@
+const { User } = require('../models')
+
+module.exports = {
+  getUsers: async (req, res, next) => {
+    try {
+      const users = await User.findAll({
+        where: { role: 'user' },
+        order: [['totalTweets', 'DESC']],
+        raw: true,
+        nest: true
+      })
+
+      return res.status(200).json(users)
+
+    } catch (err) { next(err) }
+  }
+}

--- a/controllers/admin-controller.js
+++ b/controllers/admin-controller.js
@@ -6,9 +6,9 @@ module.exports = {
       const users = await User.findAll({
         where: { role: 'user' },
         order: [['totalTweets', 'DESC']],
-        raw: true,
-        nest: true
+        raw: true
       })
+      if (!users.length) throw new Error('沒有任何使用者!')
 
       return res.status(200).json(users)
 
@@ -19,9 +19,9 @@ module.exports = {
     try {
       const tweets = await Tweet.findAll({
         order: [['createdAt', 'DESC']],
-        raw: true,
-        nest: true
+        raw: true
       })
+      if (!tweets.length) throw new Error('沒有任何推文!')
 
       return res.status(200).json(tweets)
 

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -15,7 +15,7 @@ module.exports = {
       // user object is automatically added up in unit test,
       // but in other scenarios,
       // we still need to retrieve user data from JWT auth,
-      if (user.avatar) { req.user = user.toJSON() }
+      if (user.role) { req.user = user.toJSON() }
 
       return next()
     })(req, res, next)
@@ -23,7 +23,7 @@ module.exports = {
 
   authenticatedAdmin: (req, res, next) => {
     const user = helpers.getUser(req)
-    if (user && user.role === 'admin') next()
+    if (user && user.role === 'admin') return next()
 
     return res.status(403).json({
       status: 'error',

--- a/routes/modules/admin.js
+++ b/routes/modules/admin.js
@@ -2,9 +2,11 @@ const express = require('express')
 const router = express.Router()
 const passport = require('../../config/passport')
 const userController = require('../../controllers/user-controller')
+const adminController = require('../../controllers/admin-controller')
 const { authenticated, authenticatedAdmin } = require('../../middleware/auth')
 
 
+router.get('/users', authenticated, authenticatedAdmin, adminController.getUsers)
 router.post(
   '/signin',
   passport.authenticate('local', { session: false }),

--- a/routes/modules/admin.js
+++ b/routes/modules/admin.js
@@ -6,6 +6,7 @@ const adminController = require('../../controllers/admin-controller')
 const { authenticated, authenticatedAdmin } = require('../../middleware/auth')
 
 
+router.get('/tweets', authenticated, authenticatedAdmin, adminController.getTweets)
 router.get('/users', authenticated, authenticatedAdmin, adminController.getUsers)
 router.post(
   '/signin',

--- a/routes/modules/admin.js
+++ b/routes/modules/admin.js
@@ -6,6 +6,7 @@ const adminController = require('../../controllers/admin-controller')
 const { authenticated, authenticatedAdmin } = require('../../middleware/auth')
 
 
+router.delete('/tweets/:TweetId', authenticated, authenticatedAdmin, adminController.deleteTweet)
 router.get('/tweets', authenticated, authenticatedAdmin, adminController.getTweets)
 router.get('/users', authenticated, authenticatedAdmin, adminController.getUsers)
 router.post(


### PR DESCRIPTION
測試已經通過，這次新增的路由包含以下:
GET /api/admin/users
GET /api/admin/tweets
DELETE /api/admin/tweets/{TweetId}

另外有調整原先的 middleware/auth.js 裡面 authenticated 函式:
原本:
`if (user.avatar) { req.user = user.toJSON() }`
改成:
`if (user.role) { req.user = user.toJSON() }`

因為後台路由在跑測試的時候，因為不會帶上 avatar 的假資料，
所以在到 authenticatedAdmin 時，會無法取得任何 user 資訊，
雖然這是一個workaround，但是至少解決目前的問題。
