### PR TITLE
Feat/add users replied tweets routes ( 新增 GET /api/users/:UserId/replied_tweets

### DIFF
--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -181,16 +181,29 @@ module.exports = {
   getRepliedTweets: async (req, res, next) => {
     try {
       const { UserId } = req.params
-      const repliedTweets = await Reply.findAll({
+      const replies = await Reply.findAll({
         where: { UserId },
         include: [{
-          model: Tweet, as: 'repliedTweet',
-          include: [{ model: User, as: 'tweetedUser', attributes: { exclude: ['password'] } }]
+          model: Tweet,
+          include: [{ model: User, attributes: { exclude: ['password'] } }]
         }],
+        order: [['createdAt', 'DESC']],
         nest: true
       })
 
-      const responseData = repliedTweets
+      const responseData = replies.map(reply => {
+        reply = reply.toJSON()
+
+        // assign following two objects to reply
+        reply.repliedTweet = reply.Tweet
+        reply.repliedTweet.TweetedUser = reply.Tweet.User
+
+        // remove unnecessary key properties
+        delete reply.Tweet
+        delete reply.repliedTweet.User
+
+        return reply
+      })
 
       return res.status(200).json(responseData)
 

--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -1,7 +1,7 @@
 const jwt = require('jsonwebtoken')
 const bcrypt = require('bcryptjs')
 const helpers = require('../_helpers')
-const { User, Tweet, Like } = require('../models')
+const { User, Tweet, Like, Reply } = require('../models')
 const { Op } = require("sequelize");
 
 
@@ -171,6 +171,26 @@ module.exports = {
         order: [['createdAt', 'DESC']],
         nest: true
       })
+
+      return res.status(200).json(responseData)
+
+    } catch (err) {
+      next(err)
+    }
+  },
+  getRepliedTweets: async (req, res, next) => {
+    try {
+      const { UserId } = req.params
+      const repliedTweets = await Reply.findAll({
+        where: { UserId },
+        include: [{
+          model: Tweet, as: 'repliedTweet',
+          include: [{ model: User, as: 'tweetedUser', attributes: { exclude: ['password'] } }]
+        }],
+        nest: true
+      })
+
+      const responseData = repliedTweets
 
       return res.status(200).json(responseData)
 

--- a/models/reply.js
+++ b/models/reply.js
@@ -17,7 +17,7 @@ module.exports = (sequelize, DataTypes) => {
   });
   Reply.associate = function (models) {
     Reply.belongsTo(models.User, { foreignKey: 'UserId' })
-    Reply.belongsTo(models.Tweet, { foreignKey: 'TweetId', as: 'repliedTweet' })
+    Reply.belongsTo(models.Tweet, { foreignKey: 'TweetId' })
   };
   return Reply;
 };

--- a/models/reply.js
+++ b/models/reply.js
@@ -15,9 +15,9 @@ module.exports = (sequelize, DataTypes) => {
   }, {
     tableName: 'Replies'
   });
-  Reply.associate = function(models) {
+  Reply.associate = function (models) {
     Reply.belongsTo(models.User, { foreignKey: 'UserId' })
-    Reply.belongsTo(models.Tweet, { foreignKey: 'TweetId' })
+    Reply.belongsTo(models.Tweet, { foreignKey: 'TweetId', as: 'repliedTweet' })
   };
   return Reply;
 };

--- a/models/tweet.js
+++ b/models/tweet.js
@@ -18,7 +18,7 @@ module.exports = (sequelize, DataTypes) => {
   });
   Tweet.associate = function (models) {
     Tweet.hasMany(models.Reply, { foreignKey: 'TweetId' })
-    Tweet.belongsTo(models.User, { foreignKey: 'UserId', as: 'tweetedUser' })
+    Tweet.belongsTo(models.User, { foreignKey: 'UserId' })
     Tweet.hasMany(models.Like, { foreignKey: 'TweetId' })
     Tweet.belongsToMany(models.User, {
       through: models.Like,

--- a/models/tweet.js
+++ b/models/tweet.js
@@ -16,9 +16,9 @@ module.exports = (sequelize, DataTypes) => {
   }, {
     tableName: 'Tweets'
   });
-  Tweet.associate = function(models) {
+  Tweet.associate = function (models) {
     Tweet.hasMany(models.Reply, { foreignKey: 'TweetId' })
-    Tweet.belongsTo(models.User, { foreignKey: 'UserId' })
+    Tweet.belongsTo(models.User, { foreignKey: 'UserId', as: 'tweetedUser' })
     Tweet.hasMany(models.Like, { foreignKey: 'TweetId' })
     Tweet.belongsToMany(models.User, {
       through: models.Like,

--- a/models/user.js
+++ b/models/user.js
@@ -25,7 +25,7 @@ module.exports = (sequelize, DataTypes) => {
     tableName: 'Users'
   });
   User.associate = function(models) {
-    User.hasMany(models.Tweet, { foreignKey: 'UserId' })
+    User.hasMany(models.Tweet, { foreignKey: 'UserId'})
     User.hasMany(models.Reply, { foreignKey: 'UserId' })
     User.hasMany(models.Like, { foreignKey: 'UserId' })
     User.belongsToMany(models.Tweet, {

--- a/routes/modules/user.js
+++ b/routes/modules/user.js
@@ -8,6 +8,7 @@ router.post('/', userController.signup)
 router.get('/:UserId', authenticated, userController.getUser)
 router.put('/:UserId', authenticated, userController.putUser)
 router.get('/:UserId/likes', authenticated, userController.getLikedTweets)
+router.get('/:UserId/replied_tweets', authenticated, userController.getRepliedTweets)
 router.get('/:UserId/tweets', authenticated, userController.getTweetsOfUser)
 
 


### PR DESCRIPTION
通過本地 GET /api/users/:UserId/replied_tweets 單元測試，以及 postman 測試。

提出問題:
1.原先採用 model as 方式直接轉換 Tweet > repliedTweet , User > tweetedUser，後續考量目前整體狀態會影響到其他路由，先調整回物件處理方式，改變物件名稱。


原先做法 : 
reply model : `Reply.belongsTo(models.Tweet, { foreignKey: 'TweetId', as: 'repliedTweet' })`
tweet model : `Tweet.belongsTo(models.User, { foreignKey: 'UserId', as: 'tweetedUser' })`
replied_tweets : 