### PR TITLE
Feat/add top users route (新增 Top users 路由)

### DIFF
--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -78,6 +78,44 @@ module.exports = {
 
     } catch (err) { next(err) }
   },
+
+  getTopUsers: async (req, res, next) => {
+    try {
+      const DEFAULT_LIMIT_NUMBER = 10
+      const DEFAULT_OFFSET_NUMBER = 0
+
+      // retrieve all query strings from HTTP request, and 
+      // use their values or fallback default values
+      const fieldArray = Object.keys(helpers.getUser(req))
+
+      const field = req.query.field?.trim() || 'totalFollowers'
+      if (!fieldArray.includes(field)) {
+        throw new Error('提供的欄位並不存在，動作執行失敗!')
+      }
+
+      const order = req.query.order?.trim() || 'DESC'
+      if (!['ASC', 'DESC'].includes(order)) {
+        throw new Error('提供的排序並不存在，動作執行失敗!')
+      }
+
+      const limit = Number(req.query.limit) || DEFAULT_LIMIT_NUMBER
+      const offset = Number(req.query.offset) || DEFAULT_OFFSET_NUMBER
+
+      // using previous option values to do database query
+      const responseData = await User.findAll({
+        where: { role: 'user' },
+        order: [[field, order]],
+        limit,
+        offset,
+        attributes: { exclude: ['password'] },
+        raw: true
+      })
+
+      return res.status(200).json(responseData)
+
+    } catch (err) { next(err) }
+  },
+
   getUser: async (req, res, next) => {
     try {
       const { UserId } = req.params

--- a/routes/modules/user.js
+++ b/routes/modules/user.js
@@ -4,6 +4,7 @@ const userController = require('../../controllers/user-controller')
 const { authenticated } = require('../../middleware/auth')
 
 
+router.get('/top', authenticated, userController.getTopUsers)
 router.post('/', userController.signup)
 router.get('/:UserId', authenticated, userController.getUser)
 router.put('/:UserId', authenticated, userController.putUser)


### PR DESCRIPTION
因應前端 以及 User Story 要求，新增 GET /api/users/top 路由，並且開放可帶入以下幾個query strings參數:
field: 搜尋欄位，ex: 必須是合格欄位，如果沒有帶入，採用預設 'totalFollowers'，如果帶入值有問題，直接報錯
order: 排序方式，ex: 必須是合格欄位，如果沒有帶入，採用預設 'DESC'，如果帶入值有問題，直接報錯
limit: 限制回傳數量，ex: 必須是數字，如果沒有帶入數字，或是帶入值有問題，一併使用預設數字 10
offset: 調整偏移數量，ex: 必須是數字，如果沒有帶入數字，或是帶入值有問題，一併使用預設數字 0

已經跑過測試檔案，沒有影響單元測試。
