### PR TITLE
doc: change node version information in README.md (修改 Node 版本需求)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@
 ## <strong>環境建置需求</strong>
 - Git
   - [下載連結](https://git-scm.com/downloads) 
-- Node.js 10.24.1
-  - <span style="color: red">注意:</span> `內部測試可以支援 14.16.0，但是建議使用 10.24.1`
+- Node.js 14.16.X
   - [下載連結](https://nodejs.org/dist/v14.16.0/)
 - 終端機工具 Terminal、CMD、Git Bash
   - <span style="color: red">注意:</span> `只需要上述的終端機工具項目其中一個即可`


### PR DESCRIPTION
原本是寫 10.24.1，但是發現這個版本並不支援 flatMap 語法，導致執行種子資料會出現失敗狀況，所以README.md 上面的 node 版本還是改回 14.16.X，比較保險。